### PR TITLE
refactor: refactored sponsorship status change to make it a logical delete

### DIFF
--- a/api/controllers/TripController.js
+++ b/api/controllers/TripController.js
@@ -407,7 +407,7 @@ export async function updateTripSponsorship(req, res) {
 }
 
 // Update status from a sponsorship
-export async function updateTripSponsorshipStatus(req, res) {
+export async function deleteTripSponsorshipLogically(req, res) {
   try {
     // Get trip by id
     const trip = await Trip.findById(req.params.tripId);
@@ -418,7 +418,7 @@ export async function updateTripSponsorshipStatus(req, res) {
         // Get index of sponsorship
         const sponsorshipIndex = trip.sponsorships.indexOf(sponsorship)
         // Update and save sponsorship
-        sponsorship.status = req.body.status
+        sponsorship.status = "CANCELLED"
         trip.sponsorships[sponsorshipIndex] = sponsorship
         trip.save()
         res.send(trip);

--- a/api/controllers/validators/SponsorshipValidator.js
+++ b/api/controllers/validators/SponsorshipValidator.js
@@ -45,12 +45,4 @@ const updateSponsorshipValidator = [
         .exists()
 ]
 
-const changeSponsorshipStatusValidator = [
-    check("status")
-        .exists({ checkNull: true, checkFalsy: true })
-        .withMessage("Status is required")
-        .isIn(['ACCEPTED', 'CANCELLED'])
-        .withMessage("Status does contain invalid value")
-]
-
-export { creationSponsorshipValidator, updateSponsorshipValidator, changeSponsorshipStatusValidator };
+export { creationSponsorshipValidator, updateSponsorshipValidator };

--- a/api/routes/TripRoutes.js
+++ b/api/routes/TripRoutes.js
@@ -14,7 +14,7 @@ import {
   getTripSponsorshipById,
   addSponsorship,
   updateTripSponsorship,
-  updateTripSponsorshipStatus,
+  deleteTripSponsorshipLogically,
   paySponsorship
 } from "../controllers/TripController.js";
 import { filterValidator } from "../controllers/validators/FinderValidator.js";
@@ -22,7 +22,7 @@ import handleExpressValidation from "../middlewares/ValidationHandlingMiddleware
 import { addFinder } from "../controllers/FinderController.js";
 import { creationValidator, updateValidator, cancelValidator } from "../controllers/validators/TripValidator.js";
 import { stageValidator } from "../controllers/validators/StageValidator.js";
-import { creationSponsorshipValidator, updateSponsorshipValidator, changeSponsorshipStatusValidator } from "../controllers/validators/SponsorshipValidator.js";
+import { creationSponsorshipValidator, updateSponsorshipValidator } from "../controllers/validators/SponsorshipValidator.js";
 import { getLastFinder } from "../middlewares/FinderMiddleware.js";
 import { checkTripPublished, checkCancelableTrip } from "../middlewares/BusinessRulesTrip.js";
 import { verifyUser } from "../middlewares/AuthPermissions.js";
@@ -95,11 +95,8 @@ export default function (app) {
       updateTripSponsorship
     );
 
-  app.route("/api/v1/trips/:tripId/sponsorships/:sponsorshipId/change-status")
-    .patch(
-      changeSponsorshipStatusValidator,
-      handleExpressValidation,
-      updateTripSponsorshipStatus);
+  app.route("/api/v1/trips/:tripId/sponsorships/:sponsorshipId")
+    .patch(deleteTripSponsorshipLogically);
 
   app.route("/api/v1/trips/sponsorships/:id")
     .get(getTripSponsorshipById);

--- a/docs/trip.yaml
+++ b/docs/trip.yaml
@@ -472,12 +472,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error"
-  /api/v1/trips/{tripId}/sponsorships/{sponsorshipId}/change-status:
     patch:
       tags:
         - Trips
-      description: Update status from a sponsorship
-      operationId: updateTripSponsorshipStatus
+      description: Logical remove of sponsorship
+      operationId: deleteTripSponsorshipLogically
       parameters:
         - required: true
           name: tripId
@@ -487,20 +486,10 @@ paths:
             type: string
         - required: true
           name: sponsorshipId
-          description: _id of the sponsorship to update
+          description: _id of the sponsorship to delete logically
           in: path
           schema:
             type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                status:
-                  type: string
-        description: Sponsorship from a trip to be updated
-        required: true
       responses:
         "204":
           description: Trip updated


### PR DESCRIPTION
He cambiado el endpoint de cambiar estado de un sponsorship porque solo podía cambiar a cancelado. Le he cambiado el nombre al endpoint y lo he puesto como un borrado lógico que es lo que en realidad es. Revisadlo y decidme que pensáis, si lo veis bien mergead si no, rechazad la PR.